### PR TITLE
fix: filter out 'avatarImg' property from get profile response data

### DIFF
--- a/src/features/user/sign-in.js
+++ b/src/features/user/sign-in.js
@@ -29,13 +29,13 @@ const signInUser = async ({ email, dispatch, getState, magic } = {}) => {
     // Get user info from Greenruhm
     const profileData = await getProfile(walletAddress);
 
-    const { _id: id, ...user } = profileData[walletAddress];
-    const filteredUser = Object.keys(user)
-      .filter(key => key !== 'avatarImg')
-      .reduce((obj, key) => {
-        obj[key] = user[key];
-        return obj;
-      }, {});
+    const {
+      _id: id,
+      // filter out avatarImg
+      // eslint-disable-next-line no-unused-vars
+      avatarImg,
+      ...user
+    } = profileData[walletAddress];
 
     if (!id) throw new Error('Account not found.');
 
@@ -43,7 +43,7 @@ const signInUser = async ({ email, dispatch, getState, magic } = {}) => {
     updateLastSignedIn(id);
 
     const userData = {
-      ...filteredUser,
+      ...user,
       id,
       walletAddress,
       email,


### PR DESCRIPTION
This change is part of the fix for #22 

GET `/api/profile/[profileId]` now includes `avatarImage` and `avatarImg` properties in the response (with `avatarImage` being an alias for `avatarImg`). 

In order to have `connect` be consistent with the docs, we are now filtering out `avatarImg` from the response data returned in the GET `/api/profile/[profileId]` call.

Related:
* [connect issue#22: add 'avatarImage' alias for 'avatarImg' gql field](https://github.com/Greenruhm/greenruhm-web/pull/684)

