### PR TITLE
chore: update build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,4 +110,4 @@ dist/
 .swc
 
 # Build artifacts
-components/
+ui/

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "watch": "watch 'npm run -s test && npm run -s lint' src",
     "update": "updtr",
     "release": "standard-version && git push --follow-tags && npm publish",
-    "prepare": "rm -rf ./components && swc --config-file .swcrc-build -d . src/components"
+    "prepare": "rm -rf ./ui && swc --config-file .swcrc-build -d ui src"
   },
   "pre-commit": [
     "lint",
@@ -68,7 +68,7 @@
     "prop-types": "15.8.1"
   },
   "files": [
-    "components",
+    "ui",
     "src",
     "styles",
     "docs"


### PR DESCRIPTION
Closes #75

With the updated configuration, all files under `src/` folder are going to be processed by SWC and the resulting files are going to be pushed into `ui/` folder.

This means that, currently, it would be possible to import `connect` from `@greenruhm/connect` and `@greenruhm/connect/ui`, since `connect` is located at the `index.js` file in both these folders.

It would also be possible for projects that run build steps in `node_modules` to import components from `@greenruhm/connect/components`, since the original files are still in the `src/` folder.

To import the built components, the user has to import `@greenruhm/connect/ui/components/name-of-component`.